### PR TITLE
Methods added to Proxy in file about_proxy_object_project

### DIFF
--- a/about_proxy_object_project.rb
+++ b/about_proxy_object_project.rb
@@ -13,16 +13,30 @@ require File.expand_path(File.dirname(__FILE__) + '/neo')
 # of the Proxy class is given in the AboutProxyObjectProject koan.
 
 class Proxy
+  attr_reader :messages
+
   def initialize(target_object)
     @object = target_object
-    # ADD MORE CODE HERE
+    @messages = Array.new
   end
 
   # WRITE CODE HERE
+  def method_missing(method_name, *arguments, &block)
+    @messages << method_name
+    @object.send method_name, *arguments, &block
+  end
+
+  def called?(method_name)
+    @messages.include? method_name
+  end
+
+  def number_of_times_called(method_name)
+    @messages.count(method_name)
+  end
 end
 
 # The proxy object should pass the following Koan:
-#
+
 class AboutProxyObjectProject < Neo::Koan
   def test_proxy_method_returns_wrapped_object
     # NOTE: The Television class is defined below


### PR DESCRIPTION
Methods Proxy#method_missing, Proxy#called? and Proxy#number_of_times_called added to the file about_proxy_object_project.